### PR TITLE
Update course's links and alternative Swift use

### DIFF
--- a/_posts/2000-01-01-swift.md
+++ b/_posts/2000-01-01-swift.md
@@ -6,10 +6,12 @@ category: section
 
 Swift to język programowania stworzony do pisania natywnych aplikacji na systemy iOS, macOS, watchOS i tvOS. 
 
-Aby zacząć pisać w Swift, potrzebujesz komputera z macOS z zainstalowanym środowiskiem programistycznym [Xcode], oraz [konto deweloperskie Apple].  
+Aby zacząć pisać w Swift jako deweloper aplikacji na platformy Apple, potrzebujesz komputera z macOS z zainstalowanym środowiskiem programistycznym [Xcode], oraz [konto deweloperskie Apple]. 
+W Swifcie można również pisać aplikacje na [Linuxa]. 
+Na Githubie jest też dostępny framework - Vapor, czyli [Server Side] w Swift. 
 
 - [Dokumentacja Swift]
-- [iOS 11 & Swift 4: From Beginner to Paid Professional] - bardzo dobry kurs dla początkujących, Mark Price bardzo dobrze wprowadza w środowisko, wszystko jest wytłumaczone jasno i zwięźle. Warto polować na promocje na Udemy, wtedy kurs możemy kupić za mniej niż 40zł.
+- [iOS 12 & Swift 4: From Beginner to Paid Professional] - bardzo dobry kurs dla początkujących, Mark Price bardzo dobrze wprowadza w środowisko, wszystko jest wytłumaczone jasno i zwięźle. Warto polować na promocje na Udemy, wtedy kurs możemy kupić za mniej niż 40zł.
 - [Książki objc.io]
 - [Kurs Uniwersytetu Stanford] - kurs wideo przedstawiający jak poprawnie i wydajnie używać języka Swift oraz bibliotek od Apple. Omawia również podstawy Swift. Kurs jest też dostępny na kanale [Michel Deiman] na Youtubie. Zalecany dla osób, które znają w minimalnym stopniu Swift lub podobny język programowania.
 - [Ray Wenderlich]
@@ -18,9 +20,11 @@ Aby zacząć pisać w Swift, potrzebujesz komputera z macOS z zainstalowanym śr
 [Xcode]: https://developer.apple.com/xcode/
 [konto deweloperskie Apple]: https://developer.apple.com/account/
 [Dokumentacja Swift]: http://apple.co/2gSmXqQ
-[iOS 11 & Swift 4: From Beginner to Paid Professional]: https://www.udemy.com/devslopes-ios11/
+[iOS 12 & Swift 4: From Beginner to Paid Professional]: https://www.udemy.com/devslopes-ios12/
 [Książki objc.io]: https://www.objc.io
 [Kurs Uniwersytetu Stanford]: https://itunes.apple.com/us/podcast/developing-ios-11-apps-with-swift/id1315130780?mt=2
 [Michel Deiman]: https://www.youtube.com/watch?v=71pyOB4TPRE&list=PLPA-ayBrweUzGFmkT_W65z64MoGnKRZMq
 [Ray Wenderlich]: https://www.raywenderlich.com/category/swift
 [Hacking with Swift]: https://www.hackingwithswift.com
+[Linuxa]: https://swift.org/blog/swift-linux-port/
+[Server Side]: https://github.com/vapor/vapor


### PR DESCRIPTION
There is a new course on Udemy for developing apps on iOS (for iOS 12).
Swift can be used in some different ways and it's worth the attention, so I added links for the most popular ones (server side and Linux).